### PR TITLE
Set kubernetes_version for helm chart explicitely

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,6 +6,7 @@ parameters:
       stackgres-operator:
         source: "https://stackgres.io/downloads/stackgres-k8s/stackgres/helm/"
         version: "1.4.0"
+    kubernetesVersion: "${dynamic_facts:kubernetesVersion:major}.${dynamic_facts:kubernetesVersion:minor}"
     helmValues:
       deploy:
         restapi: false

--- a/class/stackgres-operator.yml
+++ b/class/stackgres-operator.yml
@@ -24,6 +24,7 @@ parameters:
           name: stackgres-operator
           namespace: ${stackgres_operator:namespace}
           api_versions: "project.openshift.io/v1"
+          kube_version: ${stackgres_operator:kubernetesVersion}
   commodore:
     postprocess:
       filters:

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,6 +1,10 @@
 # Overwrite parameters here
 
 parameters:
+  dynamic_facts:
+    kubernetesVersion:
+      major: 1
+      minor: 24
   stackgres_operator:
     images:
       kubectl:


### PR DESCRIPTION
With helm v3.11 which is used by the latest commodore version, the default kubernetes version is now `1.26`. This causes issues with this chart, as it only supports K8s up to 1.25. Setting the kube_version to the actual version of the cluster will solve the isue.

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>




## Checklist

- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
