### PR TITLE
Allow setting custom registry for the operator image

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -14,4 +14,8 @@ parameters:
       kubectl:
         repository: docker.io
         image: ongres/kubectl
-        tag: v1.24.3-build-6.16
+        tag: ""
+      stackgres_operator:
+        repository: docker.io
+        image: stackgres/operator
+        tag: ""

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/operator-deployment.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/operator-deployment.yaml
@@ -46,7 +46,7 @@ spec:
               value: IfNotPresent
             - name: EXTENSIONS_REPOSITORY_URLS
               value: https://extensions.stackgres.io/postgres/repository
-          image: stackgres/operator:1.4.0
+          image: docker.io/stackgres/operator:1.4.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
The registry of the operator image can't be overriden, as it is hardcoded in the helm chart. Using postprocessing we override the compiled image.

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
