### PR TITLE
Allow setting custom registry for the stackgres jobs image

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -19,3 +19,7 @@ parameters:
         repository: docker.io
         image: stackgres/operator
         tag: ""
+      stackgres_jobs:
+        repository: docker.io
+        image: stackgres/jobs
+        tag: ""

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/cr-updater-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/cr-updater-job.yaml
@@ -30,7 +30,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: CR_UPDATER
               value: 'true'
-          image: stackgres/jobs:1.4.0
+          image: docker.io/stackgres/jobs:1.4.0
           imagePullPolicy: IfNotPresent
           name: stackgres-jobs
           securityContext: null

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/crd-upgrade-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/crd-upgrade-job.yaml
@@ -32,7 +32,7 @@ spec:
               value: 'true'
             - name: CONVERSION_WEBHOOKS
               value: 'false'
-          image: stackgres/jobs:1.4.0
+          image: docker.io/stackgres/jobs:1.4.0
           imagePullPolicy: IfNotPresent
           name: crd-upgrade
       restartPolicy: OnFailure

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/crd-webhooks-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/crd-webhooks-job.yaml
@@ -34,7 +34,7 @@ spec:
               value: 'false'
             - name: CONVERSION_WEBHOOKS
               value: 'true'
-          image: stackgres/jobs:1.4.0
+          image: docker.io/stackgres/jobs:1.4.0
           imagePullPolicy: IfNotPresent
           name: conversion-webhooks
       restartPolicy: OnFailure


### PR DESCRIPTION
The registry of the stackgres jobs image can't be overriden, as it is hardcoded in the helm chart. Using postprocessing we override the compiled image.

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
