### PR TITLE
Switch to cert-manager managed certificates by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,18 +9,12 @@ parameters:
         version: "1.4.0"
     kubernetesVersion: "${dynamic_facts:kubernetesVersion:major}.${dynamic_facts:kubernetesVersion:minor}"
 
-    =_cert_secret_name:
-      "True": stackgres-operator-managed-certs
-      "False": stackgres-operator-certs
-
     helmValues:
       deploy:
         restapi: false
       cert:
         certManager:
           autoConfigure: true
-        # We change the certificate secret name if we switch between cluster signed and cert-manager managed certs to avoid a race condition in the setup job
-        secretName: ${stackgres_operator:_cert_secret_name:${stackgres_operator:helmValues:cert:certManager:autoConfigure}}
       operator:
         annotations:
           # This makes sure we redeploy stackgres if we change the cert config

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,6 +1,7 @@
 parameters:
   stackgres_operator:
     =_metadata: {}
+
     namespace: syn-stackgres-operator
     charts:
       stackgres-operator:
@@ -8,19 +9,24 @@ parameters:
         version: "1.4.0"
     kubernetesVersion: "${dynamic_facts:kubernetesVersion:major}.${dynamic_facts:kubernetesVersion:minor}"
 
-    certManager:
-      autoConfigure: true
+    =_cert_secret_name:
+      "True": stackgres-operator-managed-certs
+      "False": stackgres-operator-certs
 
     helmValues:
       deploy:
         restapi: false
+      cert:
+        certManager:
+          autoConfigure: true
+        # We change the certificate secret name if we switch between cluster signed and cert-manager managed certs to avoid a race condition in the setup job
+        secretName: ${stackgres_operator:_cert_secret_name:${stackgres_operator:helmValues:cert:certManager:autoConfigure}}
       operator:
         annotations:
-          # This makes sure we redeploy stackgres if we change the cert-manager config
-          cert-manager-config: >
-            ${stackgres_operator:certManager}
-      cert:
-        certManager: ${stackgres_operator:certManager}
+          # This makes sure we redeploy stackgres if we change the cert config
+          cert-config: >
+            ${stackgres_operator:helmValues:cert}
+
     images:
       kubectl:
         repository: docker.io

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,9 +7,20 @@ parameters:
         source: "https://stackgres.io/downloads/stackgres-k8s/stackgres/helm/"
         version: "1.4.0"
     kubernetesVersion: "${dynamic_facts:kubernetesVersion:major}.${dynamic_facts:kubernetesVersion:minor}"
+
+    certManager:
+      autoConfigure: true
+
     helmValues:
       deploy:
         restapi: false
+      operator:
+        annotations:
+          # This makes sure we redeploy stackgres if we change the cert-manager config
+          cert-manager-config: >
+            ${stackgres_operator:certManager}
+      cert:
+        certManager: ${stackgres_operator:certManager}
     images:
       kubectl:
         repository: docker.io

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -14,11 +14,18 @@ The namespace in which to deploy this component.
 
 [horizontal]
 type:: dict
-default:: `{}`
 
 List of Helm values to pass to the Helm chart.
-For a list of supported values see: https://stackgres.io/doc/latest/install/operator/parameters/[stackgres operator paramaters].
+For a list of supported values see: https://stackgres.io/doc/latest/install/operator/parameters/[stackgres operator parameters].
 
+
+By default, the rest API is disabled and certificate management by cert-manager is enabled.
+
+[WARNING]
+====
+This means by default this component requires a working cert-manager instance on the cluster.
+If cert-manager isn't installed on the target cluster, disable cert-manager support by setting `helmValues.cert.certManager.autoConfigure: false`.
+====
 
 == Example
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -29,7 +29,11 @@ If cert-manager isn't installed on the target cluster, disable cert-manager supp
 
 [IMPORTANT]
 ====
-If you need to switch from or the cert-manager generated certificates you will have to manually remove the secrets `stackgres-operator-certs` and `stackgres-operator-ca` *before* applying the catalog.
+When switching from or to cert-manager generated certificates can't be done automatically, but needs manual intervention.
+*Before* modifying `helmValues.cert.certManager.autoConfigure` you'll have to manually remove the secrets `stackgres-operator-certs` and `stackgres-operator-ca` from the operator namespace.
+This is necessary as the installation jobs won't clean up old certificates, which will lead to certificate validation errors.
+
+Please be aware that this will result in downtime for the operator.
 ====
 
 == Example

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -27,6 +27,11 @@ This means by default this component requires a working cert-manager instance on
 If cert-manager isn't installed on the target cluster, disable cert-manager support by setting `helmValues.cert.certManager.autoConfigure: false`.
 ====
 
+[IMPORTANT]
+====
+If you need to switch from or the cert-manager generated certificates you will have to manually remove the secrets `stackgres-operator-certs` and `stackgres-operator-ca` *before* applying the catalog.
+====
+
 == Example
 
 [source,yaml]

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/configure-cert-manager-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/configure-cert-manager-job.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: '5'
+  labels:
+    app: stackgres-operator
+    job: configure-cert-manager
+    scope: init
+  name: stackgres-operator-configure-cert-manager
+  namespace: syn-stackgres-operator
+spec:
+  template:
+    metadata:
+      labels:
+        app: stackgres-operator
+        job: configure-cert-manager
+        scope: init
+    spec:
+      containers:
+        - command:
+            - /bin/bash
+            - -ecx
+            - "cat << EOF | kubectl apply -f -\n---\napiVersion: cert-manager.io/v1\n\
+              kind: Issuer\nmetadata:\n  name: \"stackgres-operator-self-signed-issuer\"\
+              \n  namespace: \"syn-stackgres-operator\"\nspec:\n  selfSigned: {}\n\
+              ---\napiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n\
+              \  name: \"stackgres-operator-ca\"\n  namespace: \"syn-stackgres-operator\"\
+              \nspec:\n  isCA: true\n  commonName: \"stackgres-operator-ca\"\n  secretName:\
+              \ \"stackgres-operator-ca\"\n  privateKey:\n    algorithm: ECDSA\n \
+              \   size: 256\n  issuerRef:\n    name: \"stackgres-operator-self-signed-issuer\"\
+              \n    kind: Issuer\n    group: cert-manager.io\n---\napiVersion: cert-manager.io/v1\n\
+              kind: Issuer\nmetadata:\n  name: \"stackgres-operator-ca-issuer\"\n\
+              \  namespace: \"syn-stackgres-operator\"\nspec:\n  ca:\n    secretName:\
+              \ \"stackgres-operator-ca\"\n---\napiVersion: cert-manager.io/v1\nkind:\
+              \ Certificate\nmetadata:\n  name: \"stackgres-operator-cert\"\n  namespace:\
+              \ \"syn-stackgres-operator\"\nspec:\n  secretName: \"stackgres-operator-certs\"\
+              \n  duration: \"2160h\"\n  renewBefore: \"360h\"\n  subject:\n    organizations:\n\
+              \      - OnGres\n  isCA: false\n  privateKey:\n    algorithm: RSA\n\
+              \    encoding: \"PKCS1\"\n    size: 2048\n  usages:\n    - server auth\n\
+              \    - client auth\n  dnsNames:\n    - stackgres-operator\n    - stackgres-operator.syn-stackgres-operator\n\
+              \    - stackgres-operator.syn-stackgres-operator.svc\n    - stackgres-operator.syn-stackgres-operator.svc.cluster.local\n\
+              \  issuerRef:\n    name: \"stackgres-operator-ca-issuer\"\n    kind:\
+              \ Issuer\n    group: cert-manager.io\nEOF\n"
+          image: ongres/kubectl:v1.24.3-build-6.16
+          imagePullPolicy: IfNotPresent
+          name: configure-cert-manager
+      restartPolicy: OnFailure
+      serviceAccountName: stackgres-operator-init
+      terminationGracePeriodSeconds: 0

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/configure-cert-manager-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/configure-cert-manager-job.yaml
@@ -36,7 +36,7 @@ spec:
               \  namespace: \"syn-stackgres-operator\"\nspec:\n  ca:\n    secretName:\
               \ \"stackgres-operator-ca\"\n---\napiVersion: cert-manager.io/v1\nkind:\
               \ Certificate\nmetadata:\n  name: \"stackgres-operator-cert\"\n  namespace:\
-              \ \"syn-stackgres-operator\"\nspec:\n  secretName: \"stackgres-operator-certs\"\
+              \ \"syn-stackgres-operator\"\nspec:\n  secretName: \"stackgres-operator-managed-certs\"\
               \n  duration: \"2160h\"\n  renewBefore: \"360h\"\n  subject:\n    organizations:\n\
               \      - OnGres\n  isCA: false\n  privateKey:\n    algorithm: RSA\n\
               \    encoding: \"PKCS1\"\n    size: 2048\n  usages:\n    - server auth\n\

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/configure-cert-manager-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/configure-cert-manager-job.yaml
@@ -23,27 +23,73 @@ spec:
         - command:
             - /bin/bash
             - -ecx
-            - "cat << EOF | kubectl apply -f -\n---\napiVersion: cert-manager.io/v1\n\
-              kind: Issuer\nmetadata:\n  name: \"stackgres-operator-self-signed-issuer\"\
-              \n  namespace: \"syn-stackgres-operator\"\nspec:\n  selfSigned: {}\n\
-              ---\napiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n\
-              \  name: \"stackgres-operator-ca\"\n  namespace: \"syn-stackgres-operator\"\
-              \nspec:\n  isCA: true\n  commonName: \"stackgres-operator-ca\"\n  secretName:\
-              \ \"stackgres-operator-ca\"\n  privateKey:\n    algorithm: ECDSA\n \
-              \   size: 256\n  issuerRef:\n    name: \"stackgres-operator-self-signed-issuer\"\
-              \n    kind: Issuer\n    group: cert-manager.io\n---\napiVersion: cert-manager.io/v1\n\
-              kind: Issuer\nmetadata:\n  name: \"stackgres-operator-ca-issuer\"\n\
-              \  namespace: \"syn-stackgres-operator\"\nspec:\n  ca:\n    secretName:\
-              \ \"stackgres-operator-ca\"\n---\napiVersion: cert-manager.io/v1\nkind:\
-              \ Certificate\nmetadata:\n  name: \"stackgres-operator-cert\"\n  namespace:\
-              \ \"syn-stackgres-operator\"\nspec:\n  secretName: \"stackgres-operator-managed-certs\"\
-              \n  duration: \"2160h\"\n  renewBefore: \"360h\"\n  subject:\n    organizations:\n\
-              \      - OnGres\n  isCA: false\n  privateKey:\n    algorithm: RSA\n\
-              \    encoding: \"PKCS1\"\n    size: 2048\n  usages:\n    - server auth\n\
-              \    - client auth\n  dnsNames:\n    - stackgres-operator\n    - stackgres-operator.syn-stackgres-operator\n\
-              \    - stackgres-operator.syn-stackgres-operator.svc\n    - stackgres-operator.syn-stackgres-operator.svc.cluster.local\n\
-              \  issuerRef:\n    name: \"stackgres-operator-ca-issuer\"\n    kind:\
-              \ Issuer\n    group: cert-manager.io\nEOF\n"
+            - |
+              cat << EOF | kubectl apply -f -
+              ---
+              apiVersion: cert-manager.io/v1
+              kind: Issuer
+              metadata:
+                name: "stackgres-operator-self-signed-issuer"
+                namespace: "syn-stackgres-operator"
+              spec:
+                selfSigned: {}
+              ---
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: "stackgres-operator-ca"
+                namespace: "syn-stackgres-operator"
+              spec:
+                isCA: true
+                commonName: "stackgres-operator-ca"
+                secretName: "stackgres-operator-ca"
+                privateKey:
+                  algorithm: ECDSA
+                  size: 256
+                issuerRef:
+                  name: "stackgres-operator-self-signed-issuer"
+                  kind: Issuer
+                  group: cert-manager.io
+              ---
+              apiVersion: cert-manager.io/v1
+              kind: Issuer
+              metadata:
+                name: "stackgres-operator-ca-issuer"
+                namespace: "syn-stackgres-operator"
+              spec:
+                ca:
+                  secretName: "stackgres-operator-ca"
+              ---
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: "stackgres-operator-cert"
+                namespace: "syn-stackgres-operator"
+              spec:
+                secretName: "stackgres-operator-certs"
+                duration: "2160h"
+                renewBefore: "360h"
+                subject:
+                  organizations:
+                    - OnGres
+                isCA: false
+                privateKey:
+                  algorithm: RSA
+                  encoding: "PKCS1"
+                  size: 2048
+                usages:
+                  - server auth
+                  - client auth
+                dnsNames:
+                  - stackgres-operator
+                  - stackgres-operator.syn-stackgres-operator
+                  - stackgres-operator.syn-stackgres-operator.svc
+                  - stackgres-operator.syn-stackgres-operator.svc.cluster.local
+                issuerRef:
+                  name: "stackgres-operator-ca-issuer"
+                  kind: Issuer
+                  group: cert-manager.io
+              EOF
           image: ongres/kubectl:v1.24.3-build-6.16
           imagePullPolicy: IfNotPresent
           name: configure-cert-manager

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/crd-webhooks-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/crd-webhooks-job.yaml
@@ -29,7 +29,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
             - name: OPERATOR_CERTIFICATE_SECRET_NAME
-              value: stackgres-operator-certs
+              value: stackgres-operator-managed-certs
             - name: CRD_UPGRADE
               value: 'false'
             - name: CONVERSION_WEBHOOKS

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/crd-webhooks-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/crd-webhooks-job.yaml
@@ -29,7 +29,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
             - name: OPERATOR_CERTIFICATE_SECRET_NAME
-              value: stackgres-operator-managed-certs
+              value: stackgres-operator-certs
             - name: CRD_UPGRADE
               value: 'false'
             - name: CONVERSION_WEBHOOKS

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/create-certificate-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/create-certificate-job.yaml
@@ -23,60 +23,17 @@ spec:
         - command:
             - /bin/bash
             - -ecx
-            - "kubectl delete csr --ignore-not-found 'stackgres-operator'\ncat <<\
-              \ EOF > /tmp/csr.conf\n[req]\nreq_extensions = v3_req\ndistinguished_name\
-              \ = req_distinguished_name\n[req_distinguished_name]\n[ v3_req ]\nbasicConstraints\
-              \ = CA:FALSE\nkeyUsage = nonRepudiation, digitalSignature, keyEncipherment\n\
-              extendedKeyUsage = serverAuth\nsubjectAltName = @alt_names\n[alt_names]\n\
-              DNS.1 = stackgres-operator\nDNS.2 = stackgres-operator.syn-stackgres-operator\n\
-              DNS.3 = stackgres-operator.syn-stackgres-operator.svc\nDNS.4 = stackgres-operator.syn-stackgres-operator.svc.cluster.local\n\
-              EOF\n\nK8S_VERSION=\"$(kubectl get node --template '{{ (index .items\
-              \ 0).status.nodeInfo.kubeletVersion }}')\"\nIS_EKS=\"$(printf %s \"\
-              $K8S_VERSION\" | grep -q -eks- && echo true || echo false)\"\nK8S_VERSION=\"\
-              ${K8S_VERSION#v}\"\nK8S_VERSION=\"${K8S_VERSION%-*}\"\n\nif [ \"$(echo\
-              \ \"$K8S_VERSION\" | tr . '\\n' \\\n    | while read NUMBER; do printf\
-              \ '%05d' \"$NUMBER\"; done)\" \\\n  -ge \"$(echo \"1.22.0\" | tr . '\\\
-              n' \\\n    | while read NUMBER; do printf '%05d' \"$NUMBER\"; done)\"\
-              \ ]\nthen\n  openssl req -new -nodes -text -keyout /tmp/root.key \\\n\
-              \      -subj \"/CN=system:node:stackgres-operator.syn-stackgres-operator;/O=system:nodes\"\
-              \ \\\n      -out /tmp/server.csr \\\n      -config /tmp/csr.conf\nelse\n\
-              \  openssl req -new -nodes -text -keyout /tmp/root.key \\\n      -subj\
-              \ \"/CN=stackgres-operator.syn-stackgres-operator\" \\\n      -out /tmp/server.csr\
-              \ \\\n      -config /tmp/csr.conf\nfi\nopenssl rsa -in /tmp/root.key\
-              \ -pubout -out /tmp/root.pem\n\ncat << EOF | kubectl create -f -\n$(\n\
-              if [ \"$(echo \"$K8S_VERSION\" | tr . '\\n' \\\n    | while read NUMBER;\
-              \ do printf '%05d' \"$NUMBER\"; done)\" \\\n  -ge \"$(echo \"1.22.0\"\
-              \ | tr . '\\n' \\\n    | while read NUMBER; do printf '%05d' \"$NUMBER\"\
-              ; done)\" ]\nthen\n  echo \"apiVersion: certificates.k8s.io/v1\"\nelse\n\
-              \  echo \"apiVersion: certificates.k8s.io/v1beta1\"\nfi\n)\nkind: CertificateSigningRequest\n\
-              metadata:\n  name: stackgres-operator\nspec:\n  request: \"$(cat /tmp/server.csr\
-              \ | base64 | tr -d '\\n')\"\n  usages:\n  - digital signature\n  - key\
-              \ encipherment\n  - server auth\n$(\nif [ \"$(echo \"$K8S_VERSION\"\
-              \ | tr . '\\n' \\\n    | while read NUMBER; do printf '%05d' \"$NUMBER\"\
-              ; done)\" \\\n  -ge \"$(echo \"1.22.0\" | tr . '\\n' \\\n    | while\
-              \ read NUMBER; do printf '%05d' \"$NUMBER\"; done)\" ]\nthen\n  if \"\
-              $IS_EKS\"\n  then\n    echo \"  signerName: beta.eks.amazonaws.com/app-serving\"\
-              \n  else\n    echo \"  signerName: kubernetes.io/kubelet-serving\"\n\
-              \  fi\nfi\n)\nEOF\n\nif ! kubectl get csr 'stackgres-operator' -o yaml|grep\
-              \ -q '^    type: Approved$'\nthen\n  kubectl certificate approve 'stackgres-operator'\n\
-              \  echo -n \"Waiting for CSR approval...\"\n  until kubectl get csr\
-              \ 'stackgres-operator' -o yaml|grep -q '^    type: Approved$'\n  do\n\
-              \    echo -n .\n    sleep 2\n  done\n  echo \"approved\"\nfi\necho -n\
-              \ \"Waiting for CSR certificate generation...\"\nuntil kubectl get csr\
-              \ 'stackgres-operator' \\\n  --template '{{ if .status }}{{ if .status.certificate\
-              \ }}true{{ end }}{{ end }}' \\\n  | grep -q '^true$'\ndo\n  echo -n\
-              \ .\n  sleep 2\ndone\necho \"certificate generated\"\n\nKEY=\"$(cat\
-              \ /tmp/root.key | base64 | tr -d '\\n')\"\nPUB=\"$(cat /tmp/root.pem\
-              \ | base64 | tr -d '\\n')\"\nCRT=\"$(kubectl get csr 'stackgres-operator'\
-              \ --template '{{ .status.certificate }}' | tr -d '\\n')\"\n\nif [ -z\
-              \ \"$CRT\" ]\nthen\n  echo \"Certificate not found in CSR!\"\n  exit\
-              \ 1\nfi\ncat << EOF > /tmp/certificate-secret.yaml            \napiVersion:\
-              \ v1\nkind: Secret\nmetadata:\n  name: stackgres-operator-certs\n  namespace:\
-              \ syn-stackgres-operator\n  annotations:\n    meta.helm.sh/release-name:\
-              \ stackgres-operator\n    meta.helm.sh/release-namespace: syn-stackgres-operator\n\
-              \  labels:\n    app.kubernetes.io/managed-by: Helm\ntype: kubernetes.io/tls\n\
-              data:\n  tls.key: ${KEY}\n  tls.crt: ${CRT}\nEOF\ncat << EOF > /tmp/validating-webhook-configuration.yaml\
-              \            \napiVersion: admissionregistration.k8s.io/v1\nkind: ValidatingWebhookConfiguration\n\
+            - "echo -n \"Waiting for secret stackgres-operator-certs to be available...\"\
+              \nuntil kubectl get secret -n 'syn-stackgres-operator' 'stackgres-operator-certs'\
+              \ \\\n  --template '{{ if .data }}{{ if and (index .data \"tls.key\"\
+              ) (index .data \"tls.crt\") }}true{{ end }}{{ end }}' \\\n  | grep -q\
+              \ '^true$'\ndo\n  echo -n .\n  sleep 2\ndone\necho \"secret available\"\
+              \nKEY=\"$(kubectl get secret -n 'syn-stackgres-operator' 'stackgres-operator-certs'\
+              \ --template '{{ (index .data \"tls.key\") }}' | tr -d '\\n')\"\nCRT=\"\
+              $(kubectl get secret -n 'syn-stackgres-operator' 'stackgres-operator-certs'\
+              \ --template '{{ (index .data \"tls.crt\") }}' | tr -d '\\n')\"\ncat\
+              \ << EOF > /tmp/validating-webhook-configuration.yaml            \n\
+              apiVersion: admissionregistration.k8s.io/v1\nkind: ValidatingWebhookConfiguration\n\
               metadata:\n  name: stackgres-operator\n  namespace: syn-stackgres-operator\n\
               \  annotations:\n    meta.helm.sh/release-name: stackgres-operator\n\
               \    meta.helm.sh/release-namespace: syn-stackgres-operator\n  labels:\n\
@@ -225,15 +182,14 @@ spec:
               \      service:\n        namespace: syn-stackgres-operator\n       \
               \ name: stackgres-operator\n        path: '/stackgres/mutation/sgscript'\n\
               \      caBundle: ${CRT}\n    admissionReviewVersions: [\"v1\"]\n\nEOF\n\
-              \nkubectl delete -f /tmp/certificate-secret.yaml --ignore-not-found\n\
-              kubectl apply -f /tmp/certificate-secret.yaml\nkubectl apply -f /tmp/validating-webhook-configuration.yaml\n\
-              kubectl apply -f /tmp/mutating-webhook-configuration.yaml\ncat << EOF\
-              \ > /tmp/csr-web.conf\n[req]\nreq_extensions = v3_req\ndistinguished_name\
-              \ = req_distinguished_name\n[req_distinguished_name]\n[ v3_req ]\nbasicConstraints\
-              \ = CA:FALSE\nkeyUsage = nonRepudiation, digitalSignature, keyEncipherment\n\
-              extendedKeyUsage = serverAuth\nsubjectAltName = @alt_names\n[alt_names]\n\
-              DNS.1 = stackgres-restapi\nDNS.2 = stackgres-restapi.syn-stackgres-operator\n\
-              DNS.3 = stackgres-restapi.syn-stackgres-operator.svc\nDNS.4 = stackgres-restapi.syn-stackgres-operator.svc.cluster.local\n\
+              \nkubectl apply -f /tmp/validating-webhook-configuration.yaml\nkubectl\
+              \ apply -f /tmp/mutating-webhook-configuration.yaml\ncat << EOF > /tmp/csr-web.conf\n\
+              [req]\nreq_extensions = v3_req\ndistinguished_name = req_distinguished_name\n\
+              [req_distinguished_name]\n[ v3_req ]\nbasicConstraints = CA:FALSE\n\
+              keyUsage = nonRepudiation, digitalSignature, keyEncipherment\nextendedKeyUsage\
+              \ = serverAuth\nsubjectAltName = @alt_names\n[alt_names]\nDNS.1 = stackgres-restapi\n\
+              DNS.2 = stackgres-restapi.syn-stackgres-operator\nDNS.3 = stackgres-restapi.syn-stackgres-operator.svc\n\
+              DNS.4 = stackgres-restapi.syn-stackgres-operator.svc.cluster.local\n\
               EOF\n\nopenssl req -new -nodes -text -keyout /tmp/web.key \\\n    -subj\
               \ \"/CN=stackgres-restapi.syn-stackgres-operator\" \\\n    -out /tmp/server-web.csr\
               \ \\\n    -config /tmp/csr-web.conf\nopenssl rsa -in /tmp/web.key -pubout\

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/create-certificate-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/create-certificate-job.yaml
@@ -23,14 +23,15 @@ spec:
         - command:
             - /bin/bash
             - -ecx
-            - "echo -n \"Waiting for secret stackgres-operator-certs to be available...\"\
-              \nuntil kubectl get secret -n 'syn-stackgres-operator' 'stackgres-operator-certs'\
-              \ \\\n  --template '{{ if .data }}{{ if and (index .data \"tls.key\"\
-              ) (index .data \"tls.crt\") }}true{{ end }}{{ end }}' \\\n  | grep -q\
-              \ '^true$'\ndo\n  echo -n .\n  sleep 2\ndone\necho \"secret available\"\
-              \nKEY=\"$(kubectl get secret -n 'syn-stackgres-operator' 'stackgres-operator-certs'\
-              \ --template '{{ (index .data \"tls.key\") }}' | tr -d '\\n')\"\nCRT=\"\
-              $(kubectl get secret -n 'syn-stackgres-operator' 'stackgres-operator-certs'\
+            - "echo -n \"Waiting for secret stackgres-operator-managed-certs to be\
+              \ available...\"\nuntil kubectl get secret -n 'syn-stackgres-operator'\
+              \ 'stackgres-operator-managed-certs' \\\n  --template '{{ if .data }}{{\
+              \ if and (index .data \"tls.key\") (index .data \"tls.crt\") }}true{{\
+              \ end }}{{ end }}' \\\n  | grep -q '^true$'\ndo\n  echo -n .\n  sleep\
+              \ 2\ndone\necho \"secret available\"\nKEY=\"$(kubectl get secret -n\
+              \ 'syn-stackgres-operator' 'stackgres-operator-managed-certs' --template\
+              \ '{{ (index .data \"tls.key\") }}' | tr -d '\\n')\"\nCRT=\"$(kubectl\
+              \ get secret -n 'syn-stackgres-operator' 'stackgres-operator-managed-certs'\
               \ --template '{{ (index .data \"tls.crt\") }}' | tr -d '\\n')\"\ncat\
               \ << EOF > /tmp/validating-webhook-configuration.yaml            \n\
               apiVersion: admissionregistration.k8s.io/v1\nkind: ValidatingWebhookConfiguration\n\

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/create-certificate-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/create-certificate-job.yaml
@@ -23,15 +23,14 @@ spec:
         - command:
             - /bin/bash
             - -ecx
-            - "echo -n \"Waiting for secret stackgres-operator-managed-certs to be\
-              \ available...\"\nuntil kubectl get secret -n 'syn-stackgres-operator'\
-              \ 'stackgres-operator-managed-certs' \\\n  --template '{{ if .data }}{{\
-              \ if and (index .data \"tls.key\") (index .data \"tls.crt\") }}true{{\
-              \ end }}{{ end }}' \\\n  | grep -q '^true$'\ndo\n  echo -n .\n  sleep\
-              \ 2\ndone\necho \"secret available\"\nKEY=\"$(kubectl get secret -n\
-              \ 'syn-stackgres-operator' 'stackgres-operator-managed-certs' --template\
-              \ '{{ (index .data \"tls.key\") }}' | tr -d '\\n')\"\nCRT=\"$(kubectl\
-              \ get secret -n 'syn-stackgres-operator' 'stackgres-operator-managed-certs'\
+            - "echo -n \"Waiting for secret stackgres-operator-certs to be available...\"\
+              \nuntil kubectl get secret -n 'syn-stackgres-operator' 'stackgres-operator-certs'\
+              \ \\\n  --template '{{ if .data }}{{ if and (index .data \"tls.key\"\
+              ) (index .data \"tls.crt\") }}true{{ end }}{{ end }}' \\\n  | grep -q\
+              \ '^true$'\ndo\n  echo -n .\n  sleep 2\ndone\necho \"secret available\"\
+              \nKEY=\"$(kubectl get secret -n 'syn-stackgres-operator' 'stackgres-operator-certs'\
+              \ --template '{{ (index .data \"tls.key\") }}' | tr -d '\\n')\"\nCRT=\"\
+              $(kubectl get secret -n 'syn-stackgres-operator' 'stackgres-operator-certs'\
               \ --template '{{ (index .data \"tls.crt\") }}' | tr -d '\\n')\"\ncat\
               \ << EOF > /tmp/validating-webhook-configuration.yaml            \n\
               apiVersion: admissionregistration.k8s.io/v1\nkind: ValidatingWebhookConfiguration\n\

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/operator-deployment.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/operator-deployment.yaml
@@ -2,9 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    cert-manager-config: '{''autoConfigure'': True}
-
-      '
+    cert-config: |
+      {'certManager': {'autoConfigure': True}, 'secretName': 'stackgres-operator-managed-certs'}
   labels:
     app: stackgres-operator
     group: stackgres.io
@@ -91,4 +90,4 @@ spec:
               - key: tls.crt
                 path: server.crt
             optional: false
-            secretName: stackgres-operator-certs
+            secretName: stackgres-operator-managed-certs

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/operator-deployment.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/operator-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     cert-config: |
-      {'certManager': {'autoConfigure': True}, 'secretName': 'stackgres-operator-managed-certs'}
+      {'certManager': {'autoConfigure': True}}
   labels:
     app: stackgres-operator
     group: stackgres.io
@@ -90,4 +90,4 @@ spec:
               - key: tls.crt
                 path: server.crt
             optional: false
-            secretName: stackgres-operator-managed-certs
+            secretName: stackgres-operator-certs

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/operator-deployment.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/operator-deployment.yaml
@@ -1,6 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    cert-manager-config: '{''autoConfigure'': True}
+
+      '
   labels:
     app: stackgres-operator
     group: stackgres.io


### PR DESCRIPTION
This PR ensures that we actually renew certificates by default by enabling cert-manager support.

The helm chart supports cert-manager certificates by setting `cert.certManager.autoConfigure: true`, which works fine when installing the component on a fresh cluster, however there are some pitfalls when switching to cert-manager certificates:

1. The certificate is generated using a helm hook. This hook doesn't run unless ArgoCD sees a change in the actually deployed resources. That's why I added the cert configuration to the operator deployment as an annotation
2. There is a race-condition in the setup jobs. If the certificate secret already exists, the job will write the old certificate in the validation webhook config, which will lead to a certificate error until the sync run a second time. I documented the manual steps. Only removing the secrets first worked reliably.



Fixes #6 
## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
