### PR TITLE
Enable StackGres API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,10 @@ gen-golden: clean .compile ## Update the reference version for target `golden-di
 .PHONY: golden-diff
 golden-diff: commodore_args += -f tests/$(instance).yml
 golden-diff: clean .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
+	rm -f tests/golden/$(instance)/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
+	rm -f compiled/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
 	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) compiled/
+	git checkout tests/golden/$(instance)/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
 
 .PHONY: golden-diff-all
 golden-diff-all: recursive_target=golden-diff

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,8 +10,6 @@ parameters:
     kubernetesVersion: "${dynamic_facts:kubernetesVersion:major}.${dynamic_facts:kubernetesVersion:minor}"
 
     helmValues:
-      deploy:
-        restapi: false
       cert:
         certManager:
           autoConfigure: true

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -5,7 +5,37 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.stackgres_operator;
 
+local networkPolicy = kube.NetworkPolicy('allow-stackgres-api') + {
+  metadata+: {
+    namespace: params.namespace,
+  },
+  spec+: {
+    policyTypes: [ 'Ingress' ],
+    podSelector: {
+      matchLabels: {
+        app: 'stackgres-restapi',
+      },
+    },
+    ingress: [
+      {
+        from: [
+          {
+            namespaceSelector: {},
+          },
+        ],
+        ports: [
+          {
+            protocol: 'TCP',
+            port: 8443,
+          },
+        ],
+      },
+    ],
+  },
+};
+
 // Define outputs below
 {
   '00_namespace': kube.Namespace(params.namespace),
+  '01_network_policy': networkPolicy,
 }

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/wait-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/wait-job.yaml
@@ -26,7 +26,9 @@ spec:
             - |
               kubectl set env -n 'syn-stackgres-operator' 'deployment/stackgres-operator' DISABLE_RECONCILIATION-
               kubectl scale --timeout 1h --replicas 1 -n 'syn-stackgres-operator' 'deployment/stackgres-operator'
+              kubectl scale --timeout 1h --replicas 1 -n 'syn-stackgres-operator' 'deployment/stackgres-restapi'
               kubectl rollout status -n 'syn-stackgres-operator' 'deployment/stackgres-operator'
+              kubectl rollout status -n 'syn-stackgres-operator' 'deployment/stackgres-restapi'
           image: docker.io/ongres/kubectl:v1.24.3-build-6.16
           imagePullPolicy: IfNotPresent
           name: stackgres-operator-wait

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data:
+  clearPassword: V2pkU2RZbHNZSE93RW5tS0RoWXJBRE9ONUFIVmYxbXhpeVczTmpDOQ==
+  k8sUsername: YWRtaW4=
+  password: YWJjM2FiYzY0OTM5ZDRlZmQzOWQ1NDBkYjM4Yjk2MjEwMDUzZDRkZjkzOWE5NjY2ZTljMjFiNWZhMjU0MWE5Yw==
+kind: Secret
+metadata:
+  annotations:
+    meta.helm.sh/release-name: stackgres-operator
+    meta.helm.sh/release-namespace: syn-stackgres-operator
+  labels:
+    api.stackgres.io/auth: user
+    app.kubernetes.io/managed-by: Helm
+  name: stackgres-restapi
+  namespace: syn-stackgres-operator
+type: Opaque

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authorization-rbac.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authorization-rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    meta.helm.sh/release-name: stackgres-operator
+    meta.helm.sh/release-namespace: syn-stackgres-operator
+  labels:
+    api.stackgres.io/auth: rolebinding
+    app.kubernetes.io/managed-by: Helm
+  name: stackgres-restapi-admin
+  namespace: syn-stackgres-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: User
+    name: admin

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-cluster-role-binding.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-cluster-role-binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    meta.helm.sh/release-name: stackgres-operator
+    meta.helm.sh/release-namespace: syn-stackgres-operator
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: stackgres-restapi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: stackgres-restapi
+subjects:
+  - kind: ServiceAccount
+    name: stackgres-restapi
+    namespace: syn-stackgres-operator

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-cluster-role.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-cluster-role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    meta.helm.sh/release-name: stackgres-operator
+    meta.helm.sh/release-namespace: syn-stackgres-operator
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: stackgres-restapi
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - users
+      - groups
+      - serviceaccount
+    verbs:
+      - impersonate
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-deployment.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-deployment.yaml
@@ -1,0 +1,158 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    meta.helm.sh/release-name: stackgres-operator
+    meta.helm.sh/release-namespace: syn-stackgres-operator
+  labels:
+    app: stackgres-restapi
+    app.kubernetes.io/managed-by: Helm
+    group: stackgres.io
+    version: 1.4.0
+  name: stackgres-restapi
+  namespace: syn-stackgres-operator
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: stackgres-restapi
+      group: stackgres.io
+  template:
+    metadata:
+      labels:
+        app: stackgres-restapi
+        group: stackgres.io
+    spec:
+      containers:
+        - env:
+            - name: RESTAPI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: RESTAPI_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: AUTHENTICATION_SECRET_NAME
+              value: stackgres-restapi
+            - name: USE_ARBITRARY_USER
+              value: 'true'
+            - name: EXTENSIONS_REPOSITORY_URLS
+              value: https://extensions.stackgres.io/postgres/repository
+            - name: STACKGRES_AUTH_TYPE
+              value: jwt
+          image: stackgres/restapi:1.4.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /q/health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 10
+          name: stackgres-restapi
+          ports:
+            - containerPort: 8080
+              name: resthttp
+              protocol: TCP
+            - containerPort: 8443
+              name: resthttps
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /q/health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 2
+          securityContext: null
+          volumeMounts:
+            - mountPath: /etc/operator/certs
+              name: web-certs
+              readOnly: true
+        - args:
+            - /bin/sh
+            - -ec
+            - |
+              envsubst '
+                $GRAFANA_EMBEDDED
+                $GRAFANA_URL_PATH
+                $GRAFANA_SCHEMA
+                $GRAFANA_WEB_HOST
+                $GRAFANA_TOKEN' \
+                < /etc/nginx/template.d/stackgres-restapi.template \
+                > /etc/nginx/conf.d/stackgres-restapi.conf
+              exec nginx -g 'daemon off;'
+          env:
+            - name: GRAFANA_URL_PATH
+              value: /
+            - name: GRAFANA_SCHEMA
+              value: http
+            - name: GRAFANA_WEB_HOST
+              value: localhost:8080
+            - name: GRAFANA_TOKEN
+              value: unknown
+          image: stackgres/admin-ui:1.4.0
+          imagePullPolicy: IfNotPresent
+          name: stackgres-adminui
+          ports:
+            - containerPort: 9443
+              name: https
+              protocol: TCP
+            - containerPort: 9080
+              name: http
+              protocol: TCP
+          securityContext: null
+          volumeMounts:
+            - mountPath: /etc/operator/certs
+              name: web-certs
+              readOnly: true
+            - mountPath: /etc/nginx/nginx.conf
+              name: operator-nginx
+              readOnly: true
+              subPath: nginx.conf
+            - mountPath: /etc/nginx/template.d
+              name: operator-nginx
+              readOnly: true
+            - mountPath: /etc/nginx/conf.d
+              name: operator-nginx-etc
+              readOnly: false
+              subPath: etc/nginx/conf.d
+            - mountPath: /var/cache/nginx
+              name: operator-nginx-etc
+              readOnly: false
+              subPath: var/cache/nginx
+            - mountPath: /var/run
+              name: operator-nginx-etc
+              readOnly: false
+              subPath: var/run
+      securityContext: null
+      serviceAccountName: stackgres-restapi
+      volumes:
+        - name: web-certs
+          secret:
+            items:
+              - key: tls.key
+                path: root.key
+              - key: tls.crt
+                path: server.crt
+              - key: jwt-rsa.key
+                path: jwt-rsa.key
+              - key: jwt-rsa.pub
+                path: jwt-rsa.pub
+            optional: false
+            secretName: stackgres-operator-web-certs
+        - configMap:
+            items:
+              - key: nginx.conf
+                path: nginx.conf
+              - key: stackgres-restapi.template
+                path: stackgres-restapi.template
+            name: stackgres-restapi-nginx
+            optional: false
+          name: operator-nginx
+        - emptyDir: {}
+          name: operator-nginx-etc

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-nginx-configmap.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-nginx-configmap.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+data:
+  nginx.conf: |
+    pid        /tmp/nginx.pid;
+    events{
+    }
+    error_log  /dev/stderr  warn;
+    http {
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path       /tmp/proxy_temp_path;
+        fastcgi_temp_path     /tmp/fastcgi_temp;
+        uwsgi_temp_path       /tmp/uwsgi_temp;
+        scgi_temp_path        /tmp/scgi_temp;
+
+        client_max_body_size  20M;
+
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                        '$status $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent" "$http_x_forwarded_for"';
+        access_log  /dev/stdout  main;
+
+        sendfile        on;
+
+        keepalive_timeout  65;
+
+        include /etc/nginx/conf.d/*.conf;
+    }
+  stackgres-restapi.template: "map $http_host $my_forwarded_port {\n  default $server_port;\n\
+    \  \"~^[^\\:]+:(?<p>\\d+)$\" $p;\n}\nserver {\n  set $grafana_embedded '${GRAFANA_EMBEDDED}';\n\
+    \n  server_name  localhost;\n\n  listen       9080;\n  listen       9443 ssl;\n\
+    \  ssl_certificate         /etc/operator/certs/server.crt;\n  ssl_certificate_key\
+    \     /etc/operator/certs/root.key;\n  root   /opt/app-root/src;\n  index index.html;\n\
+    \n  location /admin/ {\n    try_files $uri $uri/index.html /admin/index.html;\n\
+    \  }\n\n  location ~ ^(/|/admin|/admin/)$ {\n    return 302 \"$scheme://$http_host/admin/index.html\"\
+    ;\n  }\n\n  location /grafana {\n    if ($grafana_embedded != true) {\n      return\
+    \ 404;\n    }\n    add_header Content-Type text/plain;\n    return 200 \"$scheme://$http_host${GRAFANA_URL_PATH}\"\
+    ;\n  }\n\n  location ~ ^(/|/stackgres|/stackgres/)$ {\n    return 302 \"$scheme://$http_host/admin/index.html\"\
+    ;\n  }\n\n  location ~ ^/stackgres {\n    proxy_redirect off;\n    proxy_set_header\
+    \ Host $host;\n    proxy_set_header X-Real-IP $remote_addr;\n    proxy_set_header\
+    \ X-Forwarded-Host $host;\n    proxy_set_header X-Forwarded-Port $my_forwarded_port;\n\
+    \    proxy_set_header X-Forwarded-Server $host;\n    proxy_set_header X-Forwarded-For\
+    \ $proxy_add_x_forwarded_for;\n    \n    proxy_pass http://localhost:8080;\n \
+    \ }\n\n  location / {\n    if ($grafana_embedded != true) {\n      return 404;\n\
+    \    }\n    proxy_set_header Host $host;\n    proxy_set_header X-Real-IP $remote_addr;\n\
+    \    proxy_set_header X-Forwarded-Host $host;\n    proxy_set_header X-Forwarded-Server\
+    \ $host;\n    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n \
+    \   index index.html index.htm;\n    proxy_set_header Authorization \"Bearer ${GRAFANA_TOKEN}\"\
+    ;\n    proxy_hide_header X-Frame-Options;\n    proxy_pass \"${GRAFANA_SCHEMA}://${GRAFANA_WEB_HOST}\"\
+    ;\n  }\n}\n"
+kind: ConfigMap
+metadata:
+  annotations:
+    meta.helm.sh/release-name: stackgres-operator
+    meta.helm.sh/release-namespace: syn-stackgres-operator
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: stackgres-restapi-nginx
+  namespace: syn-stackgres-operator

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-service-account.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    meta.helm.sh/release-name: stackgres-operator
+    meta.helm.sh/release-namespace: syn-stackgres-operator
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: stackgres-restapi
+  namespace: syn-stackgres-operator

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-service.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    meta.helm.sh/release-name: stackgres-operator
+    meta.helm.sh/release-namespace: syn-stackgres-operator
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: stackgres-restapi
+  namespace: syn-stackgres-operator
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    app: stackgres-restapi
+  type: ClusterIP

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_network_policy.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_network_policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-stackgres-api
+  name: allow-stackgres-api
+  namespace: syn-stackgres-operator
+spec:
+  egress: []
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 8443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: stackgres-restapi
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
## Summary

Enable the StackGres restAPI and add a networkpolicy to allow access to it.

This also changes the `golden-diff` target a bit, as it would always find changes in the generated password.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
