### PR TITLE
Fix webhook CA when using certmanager

### DIFF
--- a/class/stackgres-operator.yml
+++ b/class/stackgres-operator.yml
@@ -31,3 +31,6 @@ parameters:
         - type: jsonnet
           filter: postprocess/update_images.jsonnet
           path: ${_instance}/01_helmchart/stackgres-operator/templates
+        - type: jsonnet
+          filter: postprocess/fix_certmanager_ca.jsonnet
+          path: ${_instance}/01_helmchart/stackgres-operator/templates

--- a/postprocess/fix_certmanager_ca.jsonnet
+++ b/postprocess/fix_certmanager_ca.jsonnet
@@ -1,0 +1,38 @@
+/**
+ * Adjust generated yamls by helm template
+ */
+local com = import 'lib/commodore.libjsonnet';
+local inv = com.inventory();
+local params = inv.parameters.stackgres_operator;
+
+local file_extension = '.yaml';
+local file = 'create-certificate-job';
+
+local patch_webook_cmd = |||
+  kubectl annotate --overwrite validatingwebhookconfigurations stackgres-operator cert-manager.io/inject-ca-from=%(namespace)s/stackgres-operator-cert
+  kubectl annotate --overwrite mutatingwebhookconfigurations stackgres-operator cert-manager.io/inject-ca-from=%(namespace)s/stackgres-operator-cert
+||| % params;
+
+{
+  [if params.helmValues.cert.certManager.autoConfigure then file]: com.yaml_load(std.extVar('output_path') + '/' + file + file_extension) {
+    spec+: {
+      template+: {
+        spec+: {
+          containers: [
+            if c.name == 'create-certificate' then
+              c {
+                command: [
+                  super.command[0],
+                  super.command[1],
+                  super.command[2] + patch_webook_cmd,
+                ],
+              }
+            else
+              c
+            for c in super.containers
+          ],
+        },
+      },
+    },
+  },
+}

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/create-certificate-job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/create-certificate-job.yaml
@@ -204,7 +204,11 @@ spec:
               \  labels:\n    app.kubernetes.io/managed-by: Helm\ntype: kubernetes.io/tls\n\
               data:\n  tls.key: ${WEB_KEY}\n  tls.crt: ${WEB_CRT}\n  jwt-rsa.key:\
               \ ${WEB_KEY}\n  jwt-rsa.pub: ${WEB_PUB}\nEOF\n\nkubectl delete -f /tmp/web-certificate-secret.yaml\
-              \ --ignore-not-found\nkubectl apply -f /tmp/web-certificate-secret.yaml\n"
+              \ --ignore-not-found\nkubectl apply -f /tmp/web-certificate-secret.yaml\n\
+              kubectl annotate --overwrite validatingwebhookconfigurations stackgres-operator\
+              \ cert-manager.io/inject-ca-from=syn-stackgres-operator/stackgres-operator-cert\n\
+              kubectl annotate --overwrite mutatingwebhookconfigurations stackgres-operator\
+              \ cert-manager.io/inject-ca-from=syn-stackgres-operator/stackgres-operator-cert\n"
           image: docker.io/ongres/kubectl:v1.24.3-build-6.16
           imagePullPolicy: IfNotPresent
           name: create-certificate

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 data:
-  clearPassword: V2pkU2RZbHNZSE93RW5tS0RoWXJBRE9ONUFIVmYxbXhpeVczTmpDOQ==
+  clearPassword: UnlkcFJzcUlEaGNZbmw2WjRJNkZCWnRkbVBpbnlQQlRIOTZpcndYbA==
   k8sUsername: YWRtaW4=
-  password: YWJjM2FiYzY0OTM5ZDRlZmQzOWQ1NDBkYjM4Yjk2MjEwMDUzZDRkZjkzOWE5NjY2ZTljMjFiNWZhMjU0MWE5Yw==
+  password: YTYwYjVmNDk0NDA4YTBhNmU2YjUxOWMzM2UyOWI3MWNkNDczMGMyNjU4OTA0MGE1NTE1ZjlhMWI4ZDRlZTdmNg==
 kind: Secret
 metadata:
   annotations:


### PR DESCRIPTION
The cert manager implementation of the upstream helm chart has a bug that it won't update the CA in the webhook configuration once the CA is reissued, which it will be by default.

This PR adds the `inject-ca-from` annotation which will make sure that the cert manager will update the CA of the certificate once it is updated.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
