### PR TITLE
Make created REST API secret stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,7 @@ gen-golden: clean .compile ## Update the reference version for target `golden-di
 .PHONY: golden-diff
 golden-diff: commodore_args += -f tests/$(instance).yml
 golden-diff: clean .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
-	rm -f tests/golden/$(instance)/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
-	rm -f compiled/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
 	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) compiled/
-	git checkout tests/golden/$(instance)/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
 
 .PHONY: golden-diff-all
 golden-diff-all: recursive_target=golden-diff

--- a/class/stackgres-operator.yml
+++ b/class/stackgres-operator.yml
@@ -34,3 +34,9 @@ parameters:
         - type: jsonnet
           filter: postprocess/fix_certmanager_ca.jsonnet
           path: ${_instance}/01_helmchart/stackgres-operator/templates
+        - type: jsonnet
+          filter: postprocess/remove_generated_secets.jsonnet
+          path: ${_instance}/01_helmchart/stackgres-operator/templates
+        - type: jsonnet
+          filter: postprocess/fix_images.jsonnet
+          path: ${_instance}

--- a/component/scripts/set-password.sh
+++ b/component/scripts/set-password.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+pw=$(kubectl -n "$NAMESPACE" get secret stackgres-restapi -o jsonpath="{.data.password}")
+if [ -z "$pw" ]
+then
+  echo "setting password"
+  pw=$(openssl rand -base64 40)
+  pw64=$(echo -n "$pw" | base64 -w0)
+  pwSha64=$(echo -n "$USER""$pw" | sha256sum | awk -F' ' '{printf($1)}' | base64 -w0)
+
+  patch=$(printf "{\"data\": {\"clearPassword\": \"%s\",\"password\":\"%s\"}}" "$pw64" "$pwSha64")
+  kubectl -n "$NAMESPACE" patch secret stackgres-restapi --patch "$patch"
+else
+  echo "password already set"
+fi

--- a/postprocess/fix_images.jsonnet
+++ b/postprocess/fix_images.jsonnet
@@ -1,0 +1,41 @@
+/**
+ * Fixup images that are missing tags
+ *
+ * We have the feature that if we do not set tags for stackgres images, we use the tag defined by the stackgres helm chart.
+ * This, however, means, that we can't directly use these image tags for additional jobs defined outside of the helm chart.
+ *
+ * This post processing step gets the complete image from the output of the helmchart redner and patches the additional jobs.
+ */
+local com = import 'lib/commodore.libjsonnet';
+local inv = com.inventory();
+local params = inv.parameters.stackgres_operator;
+
+local reference_kubectl_image_file = com.yaml_load(std.extVar('output_path') + '/01_helmchart/stackgres-operator/templates/create-certificate-job.yaml');
+local reference_kubectl_image = reference_kubectl_image_file.spec.template.spec.containers[0].image;
+
+local file_extension = '.yaml';
+local file_names_kubectl_image = [
+  '02_set_restAPI_password_job',
+];
+
+
+{
+  [file]: com.yaml_load(std.extVar('output_path') + '/' + file + file_extension) {
+    spec+: {
+      template+: {
+        spec+: {
+          containers: [
+            if std.startsWith(c.image, '%(repository)s/%(image)s' % params.images.kubectl) then
+              c {
+                image: reference_kubectl_image,
+              }
+            else
+              c
+            for c in super.containers
+          ],
+        },
+      },
+    },
+  }
+  for file in file_names_kubectl_image
+}

--- a/postprocess/remove_generated_secets.jsonnet
+++ b/postprocess/remove_generated_secets.jsonnet
@@ -1,0 +1,25 @@
+/**
+ * We need to remove secrets generate by helm as they are not stable
+ * Secrets will be genereated through a job
+ */
+local com = import 'lib/commodore.libjsonnet';
+local inv = com.inventory();
+local params = inv.parameters.stackgres_operator;
+
+local file_extension = '.yaml';
+local file = 'webapi-authentication-secret';
+
+local pw = std.get(
+  std.get(params.helmValues, 'authentication', default={}),
+  'password',
+  default=''
+);
+
+{
+  [if pw == '' then file]: com.yaml_load(std.extVar('output_path') + '/' + file + file_extension) {
+    data+: {
+      password:: '',
+      clearPassword:: '',
+    },
+  },
+}

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -10,4 +10,3 @@ parameters:
       kubectl:
         repository: docker.io
         image: ongres/kubectl
-        tag: v1.24.3-build-6.16

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/webapi-authentication-secret.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 data:
-  clearPassword: UnlkcFJzcUlEaGNZbmw2WjRJNkZCWnRkbVBpbnlQQlRIOTZpcndYbA==
   k8sUsername: YWRtaW4=
-  password: YTYwYjVmNDk0NDA4YTBhNmU2YjUxOWMzM2UyOWI3MWNkNDczMGMyNjU4OTA0MGE1NTE1ZjlhMWI4ZDRlZTdmNg==
 kind: Secret
 metadata:
   annotations:

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/02_set_restAPI_password_job.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/02_set_restAPI_password_job.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: '10'
+  labels:
+    app: stackgres-restapi-set-password
+    job: set-password
+    scope: init
+  name: stackgres-restapi-set-password
+  namespace: syn-stackgres-operator
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: stackgres-restapi-set-password
+        job: set-password
+        scope: init
+    spec:
+      containers:
+        - args: []
+          command:
+            - /bin/bash
+            - -ecx
+            - |
+              #!/bin/bash
+
+              pw=$(kubectl -n "$NAMESPACE" get secret stackgres-restapi -o jsonpath="{.data.password}")
+              if [ -z "$pw" ]
+              then
+                echo "setting password"
+                pw=$(openssl rand -base64 40)
+                pw64=$(echo -n "$pw" | base64 -w0)
+                pwSha64=$(echo -n "$USER""$pw" | sha256sum | awk -F' ' '{printf($1)}' | base64 -w0)
+
+                patch=$(printf "{\"data\": {\"clearPassword\": \"%s\",\"password\":\"%s\"}}" "$pw64" "$pwSha64")
+                kubectl -n "$NAMESPACE" patch secret stackgres-restapi --patch "$patch"
+              else
+                echo "password already set"
+              fi
+          env:
+            - name: NAMESPACE
+              value: syn-stackgres-operator
+            - name: USER
+              value: admin
+          image: docker.io/ongres/kubectl:v1.24.3-build-6.16
+          imagePullPolicy: IfNotPresent
+          name: set-password
+          ports: []
+          stdin: false
+          tty: false
+          volumeMounts: []
+      restartPolicy: OnFailure
+      serviceAccountName: stackgres-operator-init


### PR DESCRIPTION
The feature of the helm chart to generate a secret for the REST API doesn't work through the component. It regenerates the password every time.

This PR removes the password and adds a hook job that sets the password if (and only if) it isn't set yet




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
