### PR TITLE
Add option to define namespace labels and annotations

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,6 +3,9 @@ parameters:
     =_metadata: {}
 
     namespace: syn-stackgres-operator
+    namespaceLabels: {}
+    namespaceAnnotations: {}
+
     charts:
       stackgres-operator:
         source: "https://stackgres.io/downloads/stackgres-k8s/stackgres/helm/"

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -86,7 +86,12 @@ local setRestAPIPwJob = kube.Job('stackgres-restapi-set-password') {
 
 // Define outputs below
 {
-  '00_namespace': kube.Namespace(params.namespace),
+  '00_namespace': kube.Namespace(params.namespace) {
+    metadata+: {
+      labels+: params.namespaceLabels,
+      annotations+: params.namespaceAnnotations,
+    },
+  },
   '01_network_policy': networkPolicy,
   [if pw == '' then '02_set_restAPI_password_job']: setRestAPIPwJob,
 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,6 +10,23 @@ default:: `syn-stackgres-operator`
 
 The namespace in which to deploy this component.
 
+
+== `namespaceLabels`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Additional labels to add to the created namespace.
+
+== `namespaceAnnotations`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Additional annotations to add to the created namespace.
+
 == `helmValues`
 
 [horizontal]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -6,6 +6,10 @@ parameters:
       major: 1
       minor: 24
   stackgres_operator:
+    namespaceLabels:
+      foo: bar
+    namespaceAnnotations:
+      openshift.io/node-selector: node-role.kubernetes.io/infra=
     images:
       kubectl:
         repository: docker.io

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/00_namespace.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/00_namespace.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations: {}
+  annotations:
+    openshift.io/node-selector: node-role.kubernetes.io/infra=
   labels:
+    foo: bar
     name: syn-stackgres-operator
   name: syn-stackgres-operator


### PR DESCRIPTION
This gives us some flexibilty and can be helpful in multiple situations. The main usecase currently is that we can schedule stackgres on infra nodes on OpenShift using the annotation `openshift.io/node-selector`




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
