### PR TITLE
Allow all ports but only from instance ns

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -20,13 +20,11 @@ local networkPolicy = kube.NetworkPolicy('allow-stackgres-api') + {
       {
         from: [
           {
-            namespaceSelector: {},
-          },
-        ],
-        ports: [
-          {
-            protocol: 'TCP',
-            port: 8443,
+            namespaceSelector: {
+              matchLabels: {
+                'appuio.io/billing-name': 'appcat-postgresql',
+              },
+            },
           },
         ],
       },

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_network_policy.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_network_policy.yaml
@@ -10,10 +10,9 @@ spec:
   egress: []
   ingress:
     - from:
-        - namespaceSelector: {}
-      ports:
-        - port: 8443
-          protocol: TCP
+        - namespaceSelector:
+            matchLabels:
+              appuio.io/billing-name: appcat-postgresql
   podSelector:
     matchLabels:
       app: stackgres-restapi


### PR DESCRIPTION
For some reason on APPUiO Cloud it's not possible to allow specific ports. So now it allows all ports but only from the instance namespaces.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
