### PR TITLE
Limit the heap size of postgresql containers to prevent OOM

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -27,3 +27,8 @@ parameters:
           # This makes sure we redeploy stackgres if we change the cert config
           cert-config: >
             ${stackgres_operator:helmValues:cert}
+        image:
+          # Use the jvm version of the image instead of the native due to
+          # Bug report - https://gitlab.com/ongresinc/stackgres/-/issues/2452
+          # This is a workaround for Stackgres v1.5.0 due to OOM issues in cluster-controller containers.
+          tag: ${stackgres_operator:charts:stackgres-operator:version}-jvm

--- a/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/operator-deployment.yaml
+++ b/tests/golden/defaults/stackgres-operator/stackgres-operator/01_helmchart/stackgres-operator/templates/operator-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     cert-config: |
-      {'certManager': {'autoConfigure': True}}
+      {"certManager":{"autoConfigure":true}}
   labels:
     app: stackgres-operator
     group: stackgres.io
@@ -32,7 +32,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
             - name: OPERATOR_IMAGE_VERSION
-              value: 1.5.0
+              value: 1.5.0-jvm
             - name: PROMETHEUS_AUTOBIND
               value: 'true'
             - name: USE_ARBITRARY_USER
@@ -49,7 +49,7 @@ spec:
               value: IfNotPresent
             - name: EXTENSIONS_REPOSITORY_URLS
               value: https://extensions.stackgres.io/postgres/repository
-          image: quay.io/stackgres/operator:1.5.0
+          image: quay.io/stackgres/operator:1.5.0-jvm
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Force limit java heap in all containers of PostgreSQL instances deployed by Stackgres in order to prevent OOM and eliminate PostgreSQL instance restarts. The PR will temporarily resolve the issue from this [bug report](https://gitlab.com/ongresinc/stackgres/-/issues/2452) until Stackgres fixes it in the next version.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
